### PR TITLE
update front-end to remove contacts

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,9 +8,9 @@ This repo contains the code, processes, and documentation for the data and tech 
 
 ## Status January 2025
 
-The old CEJST has been taken offline by the incoming adminsitration. This fork is maintained by communities who stillrequire access to the tool, and who hope to gradually improve it.  
+The old CEJST has been taken offline by the incoming adminsitration. This fork is maintained by communities who still require access to the tool, and who hope to gradually improve it.  
 
-**Many of the instructions in the README are not appropriate at the current stage of development.** In particular, the use of Docker and docker-compose is not advised. Instead, in this initial stage, we are only building the main web server (found in `client`). This is a Gatsby website, which uses React components to build a static site in the `client/public` folder. Further instructions are coming soon.  For now, thank you for your interest! Please use Github issues to track problems and feature requests.  
+**Many of the instructions in the README are not appropriate at the current stage of development.** In particular, the use of Docker and docker-compose is not advised. Instead, in this initial stage, we are only building the main web server (found in `client`). This is a Gatsby website, which uses React components to build a static site in the `client/public` folder. Further instructions are coming soon.  For now, thank you for your interest! Please use [Github issues](https://github.com/edgi-govdata-archiving/j40-cejst-2/issues) to track problems and feature requests.  
 
 -------------
 

--- a/client/src/components/DatasetContainer/index.tsx
+++ b/client/src/components/DatasetContainer/index.tsx
@@ -8,8 +8,8 @@ import {hyphenizeString} from '../../../cypress/integration/common/helpers';
 
 import * as styles from './dsContainer.module.scss';
 import * as METHODOLOGY_COPY from '../../data/copy/methodology';
-import {PAGES_ENDPOINTS, DATA_SURVEY_LINKS} from '../../data/constants';
-import DatasetsButton from '../DatasetsButton';
+import {PAGES_ENDPOINTS} from '../../data/constants';
+// import DatasetsButton from '../DatasetsButton';
 
 
 const DatasetContainer = () => {
@@ -35,7 +35,7 @@ const DatasetContainer = () => {
             <Grid desktop={{col: 1}}>
             </Grid>
             <Grid desktop={{col: 4}}>
-              <DatasetsButton href= {intl.locale === 'es' ? DATA_SURVEY_LINKS.ES : DATA_SURVEY_LINKS.EN} />
+              {/* <DatasetsButton href= {intl.locale === 'es' ? DATA_SURVEY_LINKS.ES : DATA_SURVEY_LINKS.EN} /> */}
             </Grid>
           </Grid>
 

--- a/client/src/components/J40Footer/J40Footer.tsx
+++ b/client/src/components/J40Footer/J40Footer.tsx
@@ -13,8 +13,8 @@ import LinkTypeWrapper from '../LinkTypeWrapper';
 
 // @ts-ignore
 import {GITHUB_LINK, GITHUB_LINK_ES} from '../../constants';
-import {PAGES_ENDPOINTS} from '../../data/constants';
-import * as ABOUT_COPY from '../../data/copy/about';
+/* import {PAGES_ENDPOINTS} from '../../data/constants';
+ */import * as ABOUT_COPY from '../../data/copy/about';
 import * as COMMON_COPY from '../../data/copy/common';
 // import whitehouseIcon from '../../images/eop-seal.svg';
 
@@ -35,7 +35,7 @@ const J40Footer = () => {
           COMMON_COPY.FOOTER_CEQ_ADDRESS.PHONE,
         ]}
       />,
-    ],
+    ], /*
     [
       intl.formatMessage(COMMON_COPY.FOOTER.MORE_INFO),
       <LinkTypeWrapper
@@ -63,7 +63,7 @@ const J40Footer = () => {
         key={'contactlink'}
         dataCy={hyphenizeString(COMMON_COPY.FOOTER.FIND_CONTACT.defaultMessage)}
       />,
-    ],
+    ], */
     [
       intl.formatMessage(COMMON_COPY.FOOTER.CONTRIBUTE),
       <LinkTypeWrapper

--- a/client/src/components/J40Footer/J40Footer.tsx
+++ b/client/src/components/J40Footer/J40Footer.tsx
@@ -1,6 +1,6 @@
 import {
   Address,
-  Logo,
+  // Logo,
   NavList,
 } from '@trussworks/react-uswds';
 import {useIntl} from 'gatsby-plugin-intl';
@@ -9,14 +9,14 @@ import React from 'react';
 import {hyphenizeString} from '../../../cypress/integration/common/helpers';
 import J40MainGridContainer from '../J40MainGridContainer';
 import LinkTypeWrapper from '../LinkTypeWrapper';
-import SurveyButton from '../SurveyButton';
+// import SurveyButton from '../SurveyButton';
 
 // @ts-ignore
 import {GITHUB_LINK, GITHUB_LINK_ES} from '../../constants';
 import {PAGES_ENDPOINTS} from '../../data/constants';
 import * as ABOUT_COPY from '../../data/copy/about';
 import * as COMMON_COPY from '../../data/copy/common';
-import whitehouseIcon from '../../images/eop-seal.svg';
+// import whitehouseIcon from '../../images/eop-seal.svg';
 
 const J40Footer = () => {
   const intl = useIntl();
@@ -100,7 +100,7 @@ const J40Footer = () => {
         </J40MainGridContainer>
       </div>
 
-      <div className="usa-footer__secondary-section">
+      {/* <div className="usa-footer__secondary-section">
         <J40MainGridContainer>
           <Logo
             size="medium"
@@ -118,8 +118,8 @@ const J40Footer = () => {
             }
           />
         </J40MainGridContainer>
-      </div>
-      <SurveyButton />
+      </div> */}
+      {/* <SurveyButton /> */}
     </footer>
   );
 };

--- a/client/src/components/J40Footer/J40Footer.tsx
+++ b/client/src/components/J40Footer/J40Footer.tsx
@@ -1,5 +1,5 @@
 import {
-  Address,
+  // Address,
   // Logo,
   NavList,
 } from '@trussworks/react-uswds';
@@ -22,6 +22,7 @@ const J40Footer = () => {
   const intl = useIntl();
 
   const NAVLINKS = [
+    /*
     [
       intl.formatMessage(COMMON_COPY.FOOTER.CONTACT),
       <Address
@@ -35,7 +36,7 @@ const J40Footer = () => {
           COMMON_COPY.FOOTER_CEQ_ADDRESS.PHONE,
         ]}
       />,
-    ], /*
+    ],
     [
       intl.formatMessage(COMMON_COPY.FOOTER.MORE_INFO),
       <LinkTypeWrapper

--- a/client/src/components/J40Header/J40Header.tsx
+++ b/client/src/components/J40Header/J40Header.tsx
@@ -222,13 +222,6 @@ const J40Header = ({location}:IJ40Header) => {
     </Link>,
     <MethNav key="methDropDown"/>,
     <AboutNav key="aboutDropDown"/>,
-    <Link
-      to={PAGES_ENDPOINTS.CONTACT}
-      key={'contact'}
-      activeClassName="usa-current"
-      data-cy={'nav-link-contact'}>
-      {intl.formatMessage(COMMON_COPY.HEADER.CONTACT)}
-    </Link>,
     <div key={'language'}>
       <Language isDesktop={false}/>
     </div>,

--- a/client/src/constants.tsx
+++ b/client/src/constants.tsx
@@ -1,2 +1,2 @@
-export const GITHUB_LINK = 'https://github.com/DOI-DO/ceq-j40-cejst-2';
+export const GITHUB_LINK = 'https://github.com/edgi-govdata-archiving/j40-cejst-2';
 export const GITHUB_LINK_ES = `${GITHUB_LINK}/blob/main/README-es.md`;

--- a/client/src/data/copy/about.tsx
+++ b/client/src/data/copy/about.tsx
@@ -42,8 +42,7 @@ export const CONTENT = {
   <FormattedMessage
     id={'about.page.paragraph.2'}
     defaultMessage={`
-      CEQ will update the tool, after reviewing public feedback,
-      research, and the availability of new data. The current version of the
+      The current version of the
       tool is version {version}.
     `}
     description={'Navigate to the About page. This is the paragraph 4'}

--- a/client/src/pages/about.tsx
+++ b/client/src/pages/about.tsx
@@ -5,14 +5,14 @@ import {useWindowSize} from 'react-use';
 import {Grid} from '@trussworks/react-uswds';
 // import AboutCard from '../components/AboutCard/AboutCard';
 // import AboutCardsContainer from '../components/AboutCard/AboutCardsContainer';
-import DatasetsButton from '../components/DatasetsButton';
+// import DatasetsButton from '../components/DatasetsButton';
 // import HowYouCanHelp from '../components/HowYouCanHelp';
 import J40MainGridContainer from '../components/J40MainGridContainer';
 import Layout from '../components/layout';
 import SubPageNav from '../components/SubPageNav';
 
 // import {GITHUB_LINK, GITHUB_LINK_ES} from '../constants';
-import {DATA_SURVEY_LINKS, PAGES_ENDPOINTS, USWDS_BREAKPOINTS} from '../data/constants';
+import {PAGES_ENDPOINTS, USWDS_BREAKPOINTS} from '../data/constants';
 import * as ABOUT_COPY from '../data/copy/about';
 // import {FEEDBACK_EMAIL} from '../data/copy/common';
 
@@ -40,7 +40,7 @@ const AboutPage = ({location}: IAboutPageProps) => {
 
         <section className={'page-heading'}>
           <h1 data-cy={'about-page-heading'}>{intl.formatMessage(ABOUT_COPY.PAGE.TITLE)}</h1>
-          <DatasetsButton href= {intl.locale === 'es' ? DATA_SURVEY_LINKS.ES : DATA_SURVEY_LINKS.EN} />
+          {/* <DatasetsButton href= {intl.locale === 'es' ? DATA_SURVEY_LINKS.ES : DATA_SURVEY_LINKS.EN} /> */}
         </section>
 
         <Grid row gap className={'j40-mb5-mt3'}>

--- a/client/src/pages/about.tsx
+++ b/client/src/pages/about.tsx
@@ -3,25 +3,25 @@ import * as React from 'react';
 import {useWindowSize} from 'react-use';
 
 import {Grid} from '@trussworks/react-uswds';
-import AboutCard from '../components/AboutCard/AboutCard';
-import AboutCardsContainer from '../components/AboutCard/AboutCardsContainer';
+// import AboutCard from '../components/AboutCard/AboutCard';
+// import AboutCardsContainer from '../components/AboutCard/AboutCardsContainer';
 import DatasetsButton from '../components/DatasetsButton';
-import HowYouCanHelp from '../components/HowYouCanHelp';
+// import HowYouCanHelp from '../components/HowYouCanHelp';
 import J40MainGridContainer from '../components/J40MainGridContainer';
 import Layout from '../components/layout';
 import SubPageNav from '../components/SubPageNav';
 
-import {GITHUB_LINK, GITHUB_LINK_ES} from '../constants';
+// import {GITHUB_LINK, GITHUB_LINK_ES} from '../constants';
 import {DATA_SURVEY_LINKS, PAGES_ENDPOINTS, USWDS_BREAKPOINTS} from '../data/constants';
 import * as ABOUT_COPY from '../data/copy/about';
-import {FEEDBACK_EMAIL} from '../data/copy/common';
+// import {FEEDBACK_EMAIL} from '../data/copy/common';
 
 
-import commentIcon from // @ts-ignore
-  '/node_modules/uswds/dist/img/usa-icons/comment.svg';
+// import commentIcon from // @ts-ignore
+//  '/node_modules/uswds/dist/img/usa-icons/comment.svg';
 
-import githubIcon from // @ts-ignore
-  '/node_modules/uswds/dist/img/usa-icons/github.svg';
+// import githubIcon from // @ts-ignore
+//  '/node_modules/uswds/dist/img/usa-icons/github.svg';
 
 interface IAboutPageProps {
   location: Location;
@@ -97,7 +97,7 @@ const AboutPage = ({location}: IAboutPageProps) => {
         </J40MainGridContainer>
       </J40MainGridContainer>
 
-      <J40MainGridContainer>
+      {/* <J40MainGridContainer>
         <h2>{intl.formatMessage(ABOUT_COPY.GET_INVOLVED.TITLE)}</h2>
         <AboutCardsContainer>
           <AboutCard
@@ -132,7 +132,7 @@ const AboutPage = ({location}: IAboutPageProps) => {
           <HowYouCanHelp/>
         </Grid>
 
-      </J40MainGridContainer>
+      </J40MainGridContainer> */}
     </Layout>);
 };
 

--- a/client/src/pages/downloads.tsx
+++ b/client/src/pages/downloads.tsx
@@ -3,13 +3,13 @@ import {useIntl} from 'gatsby-plugin-intl';
 import * as React from 'react';
 import {useWindowSize} from 'react-use';
 
-import DatasetsButton from '../components/DatasetsButton';
+// import DatasetsButton from '../components/DatasetsButton';
 import J40MainGridContainer from '../components/J40MainGridContainer';
 import Layout from '../components/layout';
 import ReleaseUpdate from '../components/ReleaseUpdate';
 import SubPageNav from '../components/SubPageNav';
 
-import {DATA_SURVEY_LINKS, PAGES_ENDPOINTS, USWDS_BREAKPOINTS} from '../data/constants';
+import {PAGES_ENDPOINTS, USWDS_BREAKPOINTS} from '../data/constants';
 import * as DOWNLOADS_COPY from '../data/copy/downloads';
 interface IDownloadsPageProps {
   location: Location;
@@ -26,7 +26,7 @@ const DownloadsPage = ({location}: IDownloadsPageProps) => {
 
         <section className={'page-heading'}>
           <h1>{intl.formatMessage(DOWNLOADS_COPY.PAGE_INTRO.PAGE_HEADING1)}</h1>
-          <DatasetsButton href= {intl.locale === 'es' ? DATA_SURVEY_LINKS.ES : DATA_SURVEY_LINKS.EN} />
+          {/* <DatasetsButton href= {intl.locale === 'es' ? DATA_SURVEY_LINKS.ES : DATA_SURVEY_LINKS.EN} /> */}
         </section>
 
         <Grid row gap className={'j40-mb5-mt3'}>

--- a/client/src/pages/frequently-asked-questions.tsx
+++ b/client/src/pages/frequently-asked-questions.tsx
@@ -4,12 +4,12 @@ import {useIntl} from 'gatsby-plugin-intl';
 import * as React from 'react';
 import {useWindowSize} from 'react-use';
 
-import DatasetsButton from '../components/DatasetsButton';
+// import DatasetsButton from '../components/DatasetsButton';
 import J40MainGridContainer from '../components/J40MainGridContainer';
 import Layout from '../components/layout';
 import SubPageNav from '../components/SubPageNav';
 
-import {DATA_SURVEY_LINKS, PAGES_ENDPOINTS, USWDS_BREAKPOINTS} from '../data/constants';
+import {PAGES_ENDPOINTS, USWDS_BREAKPOINTS} from '../data/constants';
 import {SIDE_PANEL_INIT_STATE_ICON_ALT_TEXT} from '../data/copy/explore';
 import * as FAQS_COPY from '../data/copy/faqs';
 
@@ -191,7 +191,7 @@ const FAQPage = ({location}: IFAQPageProps) => {
 
         <section className={'page-heading'}>
           <h1>{intl.formatMessage(FAQS_COPY.PAGE_INTRO.PAGE_TILE)}</h1>
-          <DatasetsButton href= {DATA_SURVEY_LINKS.EN} />
+          {/* <DatasetsButton href= {DATA_SURVEY_LINKS.EN} /> */}
         </section>
 
         <Grid row gap className={'j40-mb5-mt3'}>

--- a/client/src/pages/frequently-asked-questions.tsx
+++ b/client/src/pages/frequently-asked-questions.tsx
@@ -138,13 +138,7 @@ const FAQPage = ({location}: IFAQPageProps) => {
     ),
     (
       <>
-        <p key={15}>{FAQS_COPY.FAQ_ANSWERS.Q15_P1}</p>
-        <ul>
-          <li>{FAQS_COPY.FAQ_ANSWERS.Q15_P1_1}</li>
-          <li>{FAQS_COPY.FAQ_ANSWERS.Q15_P1_2}</li>
-          <li>{FAQS_COPY.FAQ_ANSWERS.Q15_P1_3}</li>
-          <li>{FAQS_COPY.FAQ_ANSWERS.Q15_P1_4}</li>
-        </ul>
+
       </>
     ),
     (

--- a/client/src/pages/index.tsx
+++ b/client/src/pages/index.tsx
@@ -6,10 +6,10 @@ import ExploreDataBox from '../components/ExploreDataBox';
 import J40Map from '../components/J40Map';
 import J40MainGridContainer from '../components/J40MainGridContainer';
 import Layout from '../components/layout';
-import DatasetsButton from '../components/DatasetsButton';
+// import DatasetsButton from '../components/DatasetsButton';
 
 import * as EXPLORE_COPY from '../data/copy/explore';
-import {DATA_SURVEY_LINKS} from '../data/constants';
+// import {DATA_SURVEY_LINKS} from '../data/constants';
 
 interface IMapPageProps {
   location: Location;
@@ -27,7 +27,7 @@ const ExporeToolPage = ({location}: IMapPageProps) => {
 
       <section className={'page-heading'}>
         <h1>{intl.formatMessage(EXPLORE_COPY.PAGE_INTRO.PAGE_HEADING)}</h1>
-        <DatasetsButton href= {intl.locale === 'es' ? DATA_SURVEY_LINKS.ES : DATA_SURVEY_LINKS.EN} />
+        {/* <DatasetsButton href= {intl.locale === 'es' ? DATA_SURVEY_LINKS.ES : DATA_SURVEY_LINKS.EN} /> */}
       </section>
 
       <Grid row gap className={'j40-mb5-mt3'}>

--- a/client/src/pages/methodology.tsx
+++ b/client/src/pages/methodology.tsx
@@ -5,12 +5,12 @@ import {useWindowSize} from 'react-use';
 
 import Categories from '../components/Categories';
 import DatasetContainer from '../components/DatasetContainer';
-import DatasetsButton from '../components/DatasetsButton';
+// import DatasetsButton from '../components/DatasetsButton';
 import J40MainGridContainer from '../components/J40MainGridContainer';
 import Layout from '../components/layout';
 import SubPageNav from '../components/SubPageNav';
 
-import {DATA_SURVEY_LINKS, PAGES_ENDPOINTS, USWDS_BREAKPOINTS} from '../data/constants';
+import {PAGES_ENDPOINTS, USWDS_BREAKPOINTS} from '../data/constants';
 import * as METHODOLOGY_COPY from '../data/copy/methodology';
 
 interface MethodPageProps {
@@ -29,7 +29,7 @@ const IndexPage = ({location}: MethodPageProps) => {
 
         <section className={'page-heading'}>
           <h1>{intl.formatMessage(METHODOLOGY_COPY.PAGE.HEADING)}</h1>
-          <DatasetsButton href= {intl.locale === 'es' ? DATA_SURVEY_LINKS.ES : DATA_SURVEY_LINKS.EN} />
+          {/* <DatasetsButton href= {intl.locale === 'es' ? DATA_SURVEY_LINKS.ES : DATA_SURVEY_LINKS.EN} /> */}
         </section>
 
         <Grid row gap className={'j40-mt3'}>

--- a/client/src/pages/previous-versions.tsx
+++ b/client/src/pages/previous-versions.tsx
@@ -3,14 +3,14 @@ import {useIntl} from 'gatsby-plugin-intl';
 import {useWindowSize} from 'react-use';
 
 import {Card, CardBody, CardFooter, CardGroup, CardHeader, Grid, Button} from '@trussworks/react-uswds';
-import DatasetsButton from '../components/DatasetsButton';
+// import DatasetsButton from '../components/DatasetsButton';
 import DownloadButton from '../components/DownloadButton';
 import J40MainGridContainer from '../components/J40MainGridContainer';
 import Layout from '../components/layout';
 import SubPageNav from '../components/SubPageNav';
 
 import * as PREV_VER_COPY from '../data/copy/previousVer';
-import {PAGES_ENDPOINTS, USWDS_BREAKPOINTS, DATA_SURVEY_LINKS} from '../data/constants';
+import {PAGES_ENDPOINTS, USWDS_BREAKPOINTS} from '../data/constants';
 import {getDownloadFileUrl} from '../data/copy/downloads';
 import {VERSIONS} from '../data/copy/methodology';
 // @ts-ignore
@@ -36,7 +36,7 @@ const PreviousVersions = ({location}: IPreviousVersionsProps) => {
 
         <section className={'page-heading'}>
           <h1 data-cy={'about-page-heading'}>{intl.formatMessage(PREV_VER_COPY.PAGE.TITLE)}</h1>
-          <DatasetsButton href= {intl.locale === 'es' ? DATA_SURVEY_LINKS.ES : DATA_SURVEY_LINKS.EN} />
+          {/* <DatasetsButton href= {intl.locale === 'es' ? DATA_SURVEY_LINKS.ES : DATA_SURVEY_LINKS.EN} /> */}
         </section>
 
         <Grid row gap className={'j40-mb5-mt3'}>


### PR DESCRIPTION
fixes #3 

For the most, I simply commented out the surface level elements, in case later we want to edit the underlying data (e.g. links, copy).

This won't update the live/public Github Pages page, but eventually the two (this repo and that) can be brought together.