### PR TITLE
Small text edits & commented out the tract feedback button and FAQ page

### DIFF
--- a/client/src/components/AreaDetail/AreaDetail.tsx
+++ b/client/src/components/AreaDetail/AreaDetail.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable quotes */
 // External Libs:
-import {Accordion, Button, Icon} from "@trussworks/react-uswds";
+import {Accordion} from "@trussworks/react-uswds"; // button and icon removed with the removal of the feedback button
 import {MessageDescriptor, useIntl} from "gatsby-plugin-intl";
 import React from "react";
 
@@ -1199,8 +1199,9 @@ const AreaDetail = ({properties}: IAreaDetailProps) => {
         />
       }
 
-      {/* Send Feedback button */}
-      <a
+
+      {/* Send Feedback button - removed for now */}
+      {/*       <a
         className={styles.sendFeedbackLink}
         href={
           intl.locale === `es` ?
@@ -1219,7 +1220,8 @@ const AreaDetail = ({properties}: IAreaDetailProps) => {
             <Icon.Launch aria-label={intl.formatMessage(EXPLORE_COPY.COMMUNITY.SEND_FEEDBACK.IMG_ICON.ALT_TAG)} />
           </div>
         </Button>
-      </a>
+      </a> */}
+
 
       {/* All category accordions in this component */}
       {<Accordion multiselectable={true} items={categoryItems} className="-AreaDetail" />}

--- a/client/src/components/AreaDetail/areaDetail.module.scss
+++ b/client/src/components/AreaDetail/areaDetail.module.scss
@@ -67,7 +67,9 @@ $sidePanelLabelFontColor: #171716;
 
 }
 
-.sendFeedbackLink {
+
+// removing the send feedback button when a census tract is selected
+/* .sendFeedbackLink {
   @include u-margin-top(2);
   @include u-margin-left(2);
   @include u-margin-bottom(2);
@@ -90,7 +92,7 @@ $sidePanelLabelFontColor: #171716;
       }
     }
   }
-}
+} */
 
 //Census row styles
 .censusRow {

--- a/client/src/components/AreaDetail/areaDetail.module.scss.d.ts
+++ b/client/src/components/AreaDetail/areaDetail.module.scss.d.ts
@@ -6,14 +6,14 @@ declare namespace MapModuleScssNamespace {
     censusRow:string;
     censusLabel:string;
     censusText: string;
-    feedbackLink:string;
+    //feedbackLink:string; 
     isInFocus:string;
     versionInfo: string;
     showThresholdExceed:string;
     showCategoriesExceed: string;
     categoryHeader:string;
-    sendFeedbackLink: string;
-    sendFeedbackBtn: string;
+   // sendFeedbackLink: string;
+   // sendFeedbackBtn: string;
     buttonContainer: string;
     buttonText: string;
     buttonImage: string;

--- a/client/src/data/copy/downloads.tsx
+++ b/client/src/data/copy/downloads.tsx
@@ -234,27 +234,6 @@ export const DOWNLOAD_LINKS = {
         />,
       }}
     />,
-    <FormattedMessage
-      id={'download.page.download.file.5'}
-      key={'download.page.download.file.5'}
-      defaultMessage={`<link5>Instructions to Federal agencies on using the CEJST</link5> (.pdf {instructions})`}
-      description={'Navigate to the download page. This is sixth download file link'}
-      values={{
-        link5: COMMON_COPY.linkFn(DOWNLOAD_FILES.NARWAL.INSTRUCTIONS.URL, false, true),
-        link5es: COMMON_COPY.linkFn(DOWNLOAD_FILES.NARWAL.INSTRUCTIONS_ES.URL, false, true),
-        instructions: <FormattedNumber
-          value={DOWNLOAD_FILES.NARWAL.INSTRUCTIONS.SIZE}
-          style="unit"
-          unit="kilobyte"
-          unitDisplay="narrow"
-        />,
-        instructionsEs: <FormattedNumber
-          value={DOWNLOAD_FILES.NARWAL.INSTRUCTIONS_ES.SIZE}
-          style="unit"
-          unit="kilobyte"
-          unitDisplay="narrow"
-        />,
-      }}
-    />,
+
   ],
 };

--- a/client/src/data/copy/explore.tsx
+++ b/client/src/data/copy/explore.tsx
@@ -803,7 +803,9 @@ export const COMMUNITY = {
     defaultMessage={ 'Identified as disadvantaged?'}
     description={`Navigate to the explore the map page. When the map is in view, click on the map. The side panel will show asking IF the communities is focused on`}
   />,
-  SEND_FEEDBACK: {
+
+  // removing the send feedback button when a census tract is selected
+  /*   SEND_FEEDBACK: {
     TITLE: <FormattedMessage
       id={'explore.map.page.side.panel.send.feedback.title'}
       defaultMessage={ 'Send feedback'}
@@ -816,7 +818,8 @@ export const COMMUNITY = {
         description: `Navigate to the explore the map page. When the map is in view, click on the map. The side panel will show a send feedback icon, this is the images alt tag`,
       },
     }),
-  },
+  }, */
+
 };
 
 export const numberOfCategoriesExceeded = (categoryCount:number) => <FormattedMessage
@@ -838,7 +841,7 @@ export const numberOfCategoriesExceeded = (categoryCount:number) => <FormattedMe
 //   }}
 // />;
 
-export const SEND_FEEDBACK = defineMessages({
+/* export const SEND_FEEDBACK = defineMessages({
   EMAIL_BODY: {
     id: 'explore.map.page.side.panel.send.feedback.email.body',
     defaultMessage: `Please provide feedback about this census tract, including about the datasets, the data categories provided for this census tract, the communities who live in this census tract, and anything else relevant that CEQ should know about this census tract.
@@ -846,7 +849,7 @@ export const SEND_FEEDBACK = defineMessages({
     description: `Navigate to the explore the map page. When the map is in view, click on the map. The side panel will show link to send feedback
 `,
   },
-});
+}); */
 
 export const SIDE_PANEL_CATEGORY = defineMessages({
   INDICATOR: {

--- a/client/src/data/copy/explore.tsx
+++ b/client/src/data/copy/explore.tsx
@@ -1497,7 +1497,7 @@ export const NOTE_ON_TRIBAL_NATIONS = {
   PARA_2: <FormattedMessage
     id={'explore.map.page.under.map.note.on.tribal.nations.para.2'}
     defaultMessage={`
-      This decision was made after meaningful and robust consultation with Tribal Nations. This is consistent with CEQ’s <link1>Action Plan</link1> for Consultation and Coordination with Tribal Nations, the <link3>Memorandum</link3> on Tribal Consultation and Strengthening Nation-to-Nation Consultation, and <link2>Executive Order 13175</link2> on Consultation and Coordination With Indian Tribal Governments.
+      
     `}
     description={`Navigate to the explore the map page. Under the map, you will see tribal nations paragraph 2`}
     values={{

--- a/client/src/data/copy/faqs.tsx
+++ b/client/src/data/copy/faqs.tsx
@@ -1,15 +1,17 @@
 /* eslint-disable max-len */
-import {defineMessages, FormattedDate, FormattedMessage} from 'gatsby-plugin-intl';
-import React from 'react';
+// import {defineMessages, FormattedDate, FormattedMessage} from 'gatsby-plugin-intl';
+import {defineMessages} from 'gatsby-plugin-intl';
 
-import LinkTypeWrapper from '../../components/LinkTypeWrapper';
+// import React from 'react';
 
-import {DATA_SURVEY_LINKS, PAGES_ENDPOINTS, SITE_SATISFACTION_SURVEY_LINKS} from '../constants';
-import {CEJST_INSTRUCT, EXEC_ORDER_LINK, FED_RECOGNIZED_INDIAN_ENTITIES, WHEJAC_RECOMMENDATIONS} from './about';
-import {boldFn, FEEDBACK_EMAIL, linkFn, METH_1_0_RELEASE_DATE, METH_2_0_RELEASE_DATE} from './common';
-import {DOWNLOAD_FILES} from './downloads';
-import {EXPLORE_PAGE_LINKS} from './explore';
-import {VERSION_NUMBER} from './methodology';
+// import LinkTypeWrapper from '../../components/LinkTypeWrapper';
+
+// import {DATA_SURVEY_LINKS, PAGES_ENDPOINTS, SITE_SATISFACTION_SURVEY_LINKS} from '../constants';
+// import {CEJST_INSTRUCT, EXEC_ORDER_LINK, FED_RECOGNIZED_INDIAN_ENTITIES, WHEJAC_RECOMMENDATIONS} from './about';
+// mport {boldFn, FEEDBACK_EMAIL, linkFn, METH_1_0_RELEASE_DATE, METH_2_0_RELEASE_DATE} from './common';
+// import {DOWNLOAD_FILES} from './downloads';
+// import {EXPLORE_PAGE_LINKS} from './explore';
+// import {VERSION_NUMBER} from './methodology';
 
 export const PAGE_INTRO = defineMessages({
   PAGE_TILE: {
@@ -24,8 +26,9 @@ export const PAGE_INTRO = defineMessages({
   },
 });
 
+// commenting out all questions until we rework the FAQ page
 export const QUESTIONS = [
-  <FormattedMessage
+  /*  <FormattedMessage
     id={ 'faqs.page.Q1'}
     key={ 'faqs.page.Q1'}
     defaultMessage={ 'What is the Climate and Economic Justice Screening Tool (CEJST)?'}
@@ -120,11 +123,11 @@ export const QUESTIONS = [
     key={ 'faqs.page.Q22'}
     defaultMessage={ 'Why are some tracts disadvantaged in certain U.S. Territories because they only meet the low income threshold?'}
     description={ 'Navigate to the FAQs page, this will be Q22'}
-  />,
+  />, */
 ];
 
 export const FAQ_ANSWERS = {
-  Q1_P1: <FormattedMessage
+  /*  Q1_P1: <FormattedMessage
     id={ 'faqs.page.answers.Q1_P1'}
     defaultMessage={ 'The CEJST is a geospatial mapping tool that identifies disadvantaged communities that face burdens. The tool has an interactive map and uses datasets that are indicators of burdens.'}
     description={ 'Navigate to the FAQs page, this will be an answer, Q1_P1'}
@@ -414,5 +417,5 @@ export const FAQ_ANSWERS = {
     id={ 'faqs.page.answers.Q22'}
     defaultMessage={ 'Because some nationally-consistent datasets on indicators of environmental or climate burden used in the tool do not currently include data for certain U.S. Territories, tracts in these Territories are considered disadvantaged if they meet the low income threshold only.'}
     description={ 'Navigate to the FAQs page, this will be an answer, Q22'}
-  />,
+  />, */
 };

--- a/client/src/data/copy/methodology.tsx
+++ b/client/src/data/copy/methodology.tsx
@@ -430,7 +430,7 @@ export const DATASETS = defineMessages({
   INFO: {
     id: 'methodology.page.datasetContainer.info',
     defaultMessage: `
-      The tool’s datasets are public and consistent nationwide. They come from different sources and are high quality. The Council on Environmental Quality (CEQ) chose them based on relevance,  availability, and quality. They identify climate, environmental, and other burdens on communities.
+      The tool’s datasets are public and consistent nationwide. They come from different sources and are high quality.
     `,
     description: 'Navigate to the Methodology page. This is the description of the dataset section',
   },

--- a/client/src/pages/frequently-asked-questions.tsx
+++ b/client/src/pages/frequently-asked-questions.tsx
@@ -198,6 +198,10 @@ const FAQPage = ({location}: IFAQPageProps) => {
 
           {/* First column */}
           <Grid col={12} tablet={{col: 7}}>
+
+            {/* Adding "coming soon" to top of first column until further notice*/}
+            <h2>{intl.formatMessage(FAQS_COPY.PAGE_INTRO.COMING_SOON)}</h2>
+
             <section style={accordionContainerStyle}>
               {/* Enabling multiselect true fails a11y using axe tool */}
               <Accordion items={faqItems}/>


### PR DESCRIPTION
This PR: 

- removes the second paragraph in the "Tribal Nations" note
- removes the sentence "The Council on Environmental Quality chose them based on relevance, quality, and availability" in the methodology paragraph
- removes the link to the instructions to federal agencies on using CEJST in the methodology page
- commented out the census tract feedback survey from the side panel when a tract is selected
- commented out the FAQ Q&A text and replaced it with "coming soon!" until further notice 