### PR TITLE
Update tileserver

### DIFF
--- a/client/.env.development
+++ b/client/.env.development
@@ -6,7 +6,10 @@
 
 # Feature Tiles env variables:
 # The TILES_BASE_URL will be determined by the DATA_SOURCE env variable
-GATSBY_CDN_TILES_BASE_URL=https://static-data-screeningtool.geoplatform.gov
+# 2025-02-11: Point to the current EPIC URL
+# May need to update again soon, using cloudfront
+# GATSBY_CDN_TILES_BASE_URL=https://static-data-screeningtool.geoplatform.gov
+GATSBY_CDN_TILES_BASE_URL=https://pedp-data.s3.us-east-1.amazonaws.com/cejst-2.0
 GATSBY_LOCAL_TILES_BASE_URL=http://localhost:5000/data/data-pipeline
 
 GATSBY_DATA_PIPELINE_SCORE_PATH_LOCAL=data_pipeline/data/score

--- a/client/.env.development
+++ b/client/.env.development
@@ -9,7 +9,7 @@
 # 2025-02-11: Point to the current EPIC URL
 # May need to update again soon, using cloudfront
 # GATSBY_CDN_TILES_BASE_URL=https://static-data-screeningtool.geoplatform.gov
-GATSBY_CDN_TILES_BASE_URL=https://pedp-data.s3.us-east-1.amazonaws.com/cejst-2.0
+GATSBY_CDN_TILES_BASE_URL=https://dblew8dgr6ajz.cloudfront.net
 GATSBY_LOCAL_TILES_BASE_URL=http://localhost:5000/data/data-pipeline
 
 GATSBY_DATA_PIPELINE_SCORE_PATH_LOCAL=data_pipeline/data/score

--- a/client/.env.production
+++ b/client/.env.production
@@ -9,7 +9,7 @@
 # 2025-02-11: Point to the current EPIC URL
 # May need to update again soon, using cloudfront
 # GATSBY_CDN_TILES_BASE_URL=https://static-data-screeningtool.geoplatform.gov
-GATSBY_CDN_TILES_BASE_URL=https://pedp-data.s3.us-east-1.amazonaws.com/cejst-2.0
+GATSBY_CDN_TILES_BASE_URL=https://dblew8dgr6ajz.cloudfront.net
 
 GATSBY_2_0_TRIBAL_PATH=data-versions/2.0/data/tribal
 

--- a/client/.env.production
+++ b/client/.env.production
@@ -6,7 +6,10 @@
 
 # Feature Tiles env variables:
 # The TILES_BASE_URL will always point to the CDN
-GATSBY_CDN_TILES_BASE_URL=https://static-data-screeningtool.geoplatform.gov
+# 2025-02-11: Point to the current EPIC URL
+# May need to update again soon, using cloudfront
+# GATSBY_CDN_TILES_BASE_URL=https://static-data-screeningtool.geoplatform.gov
+GATSBY_CDN_TILES_BASE_URL=https://pedp-data.s3.us-east-1.amazonaws.com/cejst-2.0
 
 GATSBY_2_0_TRIBAL_PATH=data-versions/2.0/data/tribal
 


### PR DESCRIPTION
this hotfixes uses a new tileserver run by a PEDP partner, nwo that the federal government source is no longer active. 